### PR TITLE
Add support for tls connections to postgres

### DIFF
--- a/packages/database-backup-restorer-postgres-9.4/packaging
+++ b/packages/database-backup-restorer-postgres-9.4/packaging
@@ -21,7 +21,7 @@ POSTGRES_VERSION=9.4.11
 tar xzf postgres/postgresql-${POSTGRES_VERSION}.tar.gz
 
 pushd postgresql-${POSTGRES_VERSION}
-  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  ./configure --prefix=${BOSH_INSTALL_TARGET} --with-openssl
 
   pushd src/bin/pg_config
     make

--- a/packages/database-backup-restorer-postgres-9.6/packaging
+++ b/packages/database-backup-restorer-postgres-9.6/packaging
@@ -21,7 +21,7 @@ POSTGRES_VERSION=9.6.3
 tar xzf postgres/postgresql-${POSTGRES_VERSION}.tar.gz
 
 pushd postgresql-${POSTGRES_VERSION}
-  ./configure --prefix=${BOSH_INSTALL_TARGET}
+  ./configure --prefix=${BOSH_INSTALL_TARGET} --with-openssl
 
   pushd src/bin/pg_config
     make


### PR DESCRIPTION
Hey there, we were testing BBR and noticed that the postgres support didn't seem to support SSL/TLS connections:

```
Stderr: pg_dump: [archiver (db)] connection to database "credhub" failed: sslmode value "verify-full" invalid when SSL support is not compiled in
```

We added this flag and it seemed to Just Work™.