### PR TITLE
Avoid adding a dangling ':' if your GOPATH is empty

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export GOPATH="/Users/pivotal/workspace/backup-and-restore-sdk-release:$GOPATH"
+export GOPATH="/Users/pivotal/workspace/backup-and-restore-sdk-release${GOPATH:+:}$GOPATH"


### PR DESCRIPTION
If your GOPATH ends with a colon, every glide command including
`glide help` fails with:
```
[ERROR]	Error getting version: exit status 2.
```