### PR TITLE
Added --if-exists flag for postgres restore

### DIFF
--- a/src/github.com/cloudfoundry-incubator/database-backup-restore/integration_tests/postgres_test.go
+++ b/src/github.com/cloudfoundry-incubator/database-backup-restore/integration_tests/postgres_test.go
@@ -726,6 +726,7 @@ var _ = Describe("Postgres", func() {
 						"--format=custom",
 						fmt.Sprintf("--dbname=%s", databaseName),
 						"--clean",
+						"--if-exists",
 						HavePrefix("--use-list="),
 						artifactFile,
 					}
@@ -789,6 +790,7 @@ var _ = Describe("Postgres", func() {
 							"--format=custom",
 							fmt.Sprintf("--dbname=%s", databaseName),
 							"--clean",
+							"--if-exists",
 							HavePrefix("--use-list="),
 							artifactFile,
 						}
@@ -854,6 +856,7 @@ var _ = Describe("Postgres", func() {
 									"--format=custom",
 									fmt.Sprintf("--dbname=%s", databaseName),
 									"--clean",
+									"--if-exists",
 									HavePrefix("--use-list="),
 									artifactFile,
 								}
@@ -919,6 +922,7 @@ var _ = Describe("Postgres", func() {
 									"--format=custom",
 									fmt.Sprintf("--dbname=%s", databaseName),
 									"--clean",
+									"--if-exists",
 									HavePrefix("--use-list="),
 									artifactFile,
 								}
@@ -987,6 +991,7 @@ var _ = Describe("Postgres", func() {
 									"--format=custom",
 									fmt.Sprintf("--dbname=%s", databaseName),
 									"--clean",
+									"--if-exists",
 									HavePrefix("--use-list="),
 									artifactFile,
 								}

--- a/src/github.com/cloudfoundry-incubator/database-backup-restore/postgres/restorer.go
+++ b/src/github.com/cloudfoundry-incubator/database-backup-restore/postgres/restorer.go
@@ -44,6 +44,7 @@ func (r Restorer) Action(artifactFilePath string) error {
 		"--format=custom",
 		"--dbname=" + r.config.Database,
 		"--clean",
+                "--if-exists",
 		fmt.Sprintf("--use-list=%s", listFile.Name()),
 		artifactFilePath,
 	}

--- a/src/github.com/cloudfoundry-incubator/database-backup-restore/system_tests/postgresql/postgresql_system_test.go
+++ b/src/github.com/cloudfoundry-incubator/database-backup-restore/system_tests/postgresql/postgresql_system_test.go
@@ -93,7 +93,7 @@ var _ = Describe("postgres", func() {
 		brJob.RunOnVMAndSucceed(fmt.Sprintf("sudo rm -rf %s %s", configPath, dbDumpPath))
 	})
 
-	Context("database dump is successful", func() {
+	Context("database backup is successful", func() {
 		BeforeEach(func() {
 			configJson := fmt.Sprintf(
 				`{
@@ -110,14 +110,13 @@ var _ = Describe("postgres", func() {
 				databaseName,
 			)
 			brJob.RunOnVMAndSucceed(fmt.Sprintf("echo '%s' > %s", configJson, configPath))
-		})
-
-		It("backs up the Postgres database", func() {
 			brJob.RunOnVMAndSucceed(
 				fmt.Sprintf(`/var/vcap/jobs/database-backup-restorer/bin/backup --config %s --artifact-file %s`,
 					configPath, dbDumpPath))
 			brJob.RunOnVMAndSucceed(fmt.Sprintf("ls -l %s", dbDumpPath))
+		})
 
+		It("restores the Postgres database", func() {
 			pgConnection.RunSQLCommand("UPDATE people SET NAME = 'New Person';")
 			pgConnection.RunSQLCommand("UPDATE places SET NAME = 'New Place';")
 
@@ -133,6 +132,19 @@ var _ = Describe("postgres", func() {
 				To(ConsistOf("Old Place"))
 			Expect(pgConnection.FetchSQLColumn("SELECT name FROM places;")).
 				NotTo(ConsistOf("New Place"))
+		})
+
+		Context("when tables do not exist", func() {
+			It("restores the tables successfully", func() {
+				pgConnection.RunSQLCommand("DROP TABLE people;")
+
+				brJob.RunOnVMAndSucceed(
+					fmt.Sprintf("/var/vcap/jobs/database-backup-restorer/bin/restore --config %s --artifact-file %s",
+						configPath, dbDumpPath))
+
+				Expect(pgConnection.FetchSQLColumn("SELECT name FROM people;")).
+					To(ConsistOf("Old Person"))
+			})
 		})
 
 	})


### PR DESCRIPTION
Solves an issue where dynamically created tables ([concourse atc example](https://github.com/concourse/atc/blob/master/db/team.go#L458)) might not exist on a clean install (DR restore target).