### PR TITLE
Add postgres 13 to support bosh director v271.7.0

### DIFF
--- a/ci/manifests/postgres-13.yml
+++ b/ci/manifests/postgres-13.yml
@@ -1,0 +1,58 @@
+# Copyright (C) 2017-Present Pivotal Software, Inc. All rights reserved.
+#
+# This program and the accompanying materials are made available under
+# the terms of the under the Apache License, Version 2.0 (the "License”);
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ((deployment-name))
+
+releases:
+- name: bosh
+  version: 268.6.0
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=271.7.0
+- name: bpm
+  version: latest
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release
+
+stemcells:
+- alias: xenial
+  os: ubuntu-xenial
+  version: latest  # replaced by exact version by bosh-deployment-resource in CI
+
+instance_groups:
+- name: postgres
+  instances: 1
+  vm_type: small
+  persistent_disk_type: 10GB
+  stemcell: xenial
+  networks:
+  - name: default
+    static_ips: [((db_host))]
+  jobs:
+  - name: postgres
+    release: bosh
+    properties:
+      postgres:
+        user: ((db_username))
+        password: ((db_password))
+        listen_address: 0.0.0.0
+  - name: bpm
+    release: bpm
+  azs: [((availability_zone))]
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 2000
+  update_watch_time: 2000

--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -45,6 +45,12 @@ postgres-11-port: &postgres-11-port 5432
 postgres-11-username: &postgres-11-username test_user
 postgres-11-password: &postgres-11-password postgres_password
 
+postgres-13-deployment-name: &postgres-13-deployment-name postgres-13-dev
+postgres-13-host: &postgres-13-host 10.244.1.14
+postgres-13-port: &postgres-13-port 5432
+postgres-13-username: &postgres-13-username test_user
+postgres-13-password: &postgres-13-password postgres_password
+
 gcp-mysql-5-7-ca-cert-path: &gcp-mysql-5-7-ca-cert-path "gcp-mysql_5_7-test-server-cert.pem"
 gcp-mysql-5-7-client-cert-path: &gcp-mysql-5-7-client-cert-path "gcp-mysql_5_7-test-client-cert.pem"
 gcp-mysql-5-7-client-key-path: &gcp-mysql-5-7-client-key-path "gcp-mysql_5_7-test-client-key.pem"
@@ -204,6 +210,12 @@ resources:
   type: bosh-deployment
   source:
     deployment: *postgres-11-deployment-name
+    skip_check: true
+
+- name: postgres-13-dev-deployment
+  type: bosh-deployment
+  source:
+    deployment: *postgres-13-deployment-name
     skip_check: true
 
 - name: database-backup-restorer-deployment
@@ -492,6 +504,18 @@ jobs:
           db_host: *postgres-11-host
           availability_zone: z1
         source_file: source-file/source-file.yml
+    - put: postgres-13-dev-deployment
+      params:
+        manifest: backup-and-restore-sdk-release/ci/manifests/postgres-13.yml
+        stemcells:
+        - xenial-stemcell/*.tgz
+        vars:
+          deployment-name: *postgres-13-deployment-name
+          db_username: *postgres-13-username
+          db_password: *postgres-13-password
+          db_host: *postgres-13-host
+          availability_zone: z1
+        source_file: source-file/source-file.yml
   - task: create-ssl-user
     file: backup-and-restore-sdk-release/ci/tasks/create-ssl-user/task.yml
     params:
@@ -561,6 +585,7 @@ jobs:
           postgres_9_6_password: ((backup-and-restore-sdk-release.rds_postgres_9_6_password))
           postgres_10_password: ((backup-and-restore-sdk-release.rds_postgres_10_password))
           postgres_11_password: ((backup-and-restore-sdk-release.rds_postgres_11_password))
+          postgres_13_password: ((backup-and-restore-sdk-release.rds_postgres_13_password))
           mariadb_10_password: ((backup-and-restore-sdk-release.rds_mariadb_10_password))
       get_params:
         output_statefile: true
@@ -779,6 +804,15 @@ jobs:
         POSTGRES_USERNAME: *postgres-11-username
         POSTGRES_PORT: *postgres-11-port
         <<: *bosh-lite-creds
+    - task: postgres-system-tests-13
+      file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/task.yml
+      params:
+        TEST_SUITE_NAME: postgresql
+        POSTGRES_PASSWORD: *postgres-13-password
+        POSTGRES_HOSTNAME: *postgres-13-host
+        POSTGRES_USERNAME: *postgres-13-username
+        POSTGRES_PORT: *postgres-13-port
+        <<: *bosh-lite-creds
   - task: postgres-tls-system-tests-9.6
     file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/task.yml
     params:
@@ -932,6 +966,18 @@ jobs:
         POSTGRES_PORT: 5432
         DB_TYPE: postgres
         DB_PREFIX: postgres_11
+    - task: postgres-system-tests-13
+      file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/terraform-task.yml
+      input_mapping:
+        terraform-state: terraform-aws
+      params:
+        TEST_SUITE_NAME: postgresql
+        <<: *bosh-lite-creds
+        POSTGRES_PASSWORD: ((backup-and-restore-sdk-release.rds_postgres_13_password))
+        POSTGRES_USERNAME: root
+        POSTGRES_PORT: 5432
+        DB_TYPE: postgres
+        DB_PREFIX: postgres_13
   - in_parallel:
     - task: postgres-tls-system-tests-9.6
       file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/terraform-task.yml
@@ -975,6 +1021,20 @@ jobs:
         TEST_SSL_USER_REQUIRES_SSL: false
         DB_TYPE: postgres
         DB_PREFIX: postgres_11
+    - task: postgres-tls-system-tests-13
+      file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/terraform-task.yml
+      input_mapping:
+        terraform-state: terraform-aws
+      params:
+        TEST_SUITE_NAME: postgresql_tls
+        <<: *bosh-lite-creds
+        POSTGRES_PASSWORD: ((backup-and-restore-sdk-release.rds_postgres_13_password))
+        POSTGRES_USERNAME: root
+        POSTGRES_PORT: 5432
+        POSTGRES_CA_CERT_PATH: rds-combined-ca-bundle.pem
+        TEST_SSL_USER_REQUIRES_SSL: false
+        DB_TYPE: postgres
+        DB_PREFIX: postgres_13
 
 - name: mariadb-system-tests
   serial: true

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -30,3 +30,6 @@ postgres/postgresql-11.4.tar.gz:
   size: 25915738
   object_id: 9ceca675-79d2-4488-7653-920be0ef3d17
   sha: sha256:2043ab71f2a435a9e77b4419f804525a0b9ec1ef37d19c1c2e4013dc1cae01a7
+postgres/postgresql-13.2.tar.gz:
+  size: 27548921
+  sha: sha256:3386a40736332aceb055c7c9012ecc665188536d874d967fcc5a33e7992f8080

--- a/jobs/database-backup-restorer/templates/backup
+++ b/jobs/database-backup-restorer/templates/backup
@@ -30,7 +30,10 @@ export PG_RESTORE_10_PATH="/var/vcap/packages/database-backup-restorer-postgres-
 export PG_DUMP_11_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/pg_dump"
 export PG_RESTORE_11_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/pg_restore"
 
-export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/psql"
+export PG_DUMP_13_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/pg_dump"
+export PG_RESTORE_13_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/pg_restore"
+
+export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/psql"
 
 export MARIADB_DUMP_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysqldump"
 export MARIADB_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysql"

--- a/jobs/database-backup-restorer/templates/restore
+++ b/jobs/database-backup-restorer/templates/restore
@@ -30,7 +30,10 @@ export PG_RESTORE_10_PATH="/var/vcap/packages/database-backup-restorer-postgres-
 export PG_DUMP_11_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/pg_dump"
 export PG_RESTORE_11_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/pg_restore"
 
-export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-11/bin/psql"
+export PG_DUMP_13_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/pg_dump"
+export PG_RESTORE_13_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/pg_restore"
+
+export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-13/bin/psql"
 
 export MARIADB_DUMP_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysqldump"
 export MARIADB_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysql"

--- a/packages/database-backup-restorer-postgres-13/packaging
+++ b/packages/database-backup-restorer-postgres-13/packaging
@@ -14,22 +14,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-name: database-backup-restorer
+set -e
 
-templates:
-  backup: bin/backup
-  restore: bin/restore
+POSTGRES_VERSION=13.2
 
-packages:
-- database-backup-restorer
-- database-backup-restorer-postgres-9.4
-- database-backup-restorer-postgres-9.6
-- database-backup-restorer-postgres-10
-- database-backup-restorer-postgres-11
-- database-backup-restorer-postgres-13
-- database-backup-restorer-mariadb
-- database-backup-restorer-mysql-5.6
-- database-backup-restorer-mysql-5.7
+tar xzf postgres/postgresql-${POSTGRES_VERSION}.tar.gz
 
-properties: {}
+pushd postgresql-${POSTGRES_VERSION}
+  ./configure --prefix=${BOSH_INSTALL_TARGET} --with-openssl
+
+  pushd src/bin/pg_config
+    make
+    make install
+  popd
+
+  cp -LR src/include ${BOSH_INSTALL_TARGET}
+
+  pushd src/interfaces/libpq
+    make
+    make install
+  popd
+
+  pushd src
+    make
+    make install
+  popd
+
+  pushd contrib
+    make
+    make install
+  popd
+popd

--- a/packages/database-backup-restorer-postgres-13/spec
+++ b/packages/database-backup-restorer-postgres-13/spec
@@ -15,21 +15,9 @@
 # limitations under the License.
 
 ---
-name: database-backup-restorer
+name: database-backup-restorer-postgres-13
 
-templates:
-  backup: bin/backup
-  restore: bin/restore
+dependencies: []
 
-packages:
-- database-backup-restorer
-- database-backup-restorer-postgres-9.4
-- database-backup-restorer-postgres-9.6
-- database-backup-restorer-postgres-10
-- database-backup-restorer-postgres-11
-- database-backup-restorer-postgres-13
-- database-backup-restorer-mariadb
-- database-backup-restorer-mysql-5.6
-- database-backup-restorer-mysql-5.7
-
-properties: {}
+files:
+- postgres/postgresql-13.2.tar.gz

--- a/src/database-backup-restore/config/utilities.go
+++ b/src/database-backup-restore/config/utilities.go
@@ -16,6 +16,7 @@ type UtilitiesConfig struct {
 	Postgres94 UtilityPaths
 	Postgres10 UtilityPaths
 	Postgres11 UtilityPaths
+	Postgres13 UtilityPaths
 	Mariadb    UtilityPaths
 	Mysql56    UtilityPaths
 	Mysql57    UtilityPaths
@@ -23,6 +24,11 @@ type UtilitiesConfig struct {
 
 func GetUtilitiesConfigFromEnv() UtilitiesConfig {
 	return UtilitiesConfig{
+		Postgres13: UtilityPaths{
+			Client:  lookupEnv("PG_CLIENT_PATH"),
+			Dump:    lookupEnv("PG_DUMP_13_PATH"),
+			Restore: lookupEnv("PG_RESTORE_13_PATH"),
+		},
 		Postgres11: UtilityPaths{
 			Client:  lookupEnv("PG_CLIENT_PATH"),
 			Dump:    lookupEnv("PG_DUMP_11_PATH"),

--- a/src/database-backup-restore/database/interactor_factory.go
+++ b/src/database-backup-restore/database/interactor_factory.go
@@ -164,6 +164,11 @@ func (f InteractorFactory) getUtilitiesForPostgres(postgresVersion version.Datab
 			f.utilitiesConfig.Postgres11.Dump,
 			f.utilitiesConfig.Postgres11.Restore,
 			nil
+	} else if semVer.MajorVersionMatches(version.SemVer("13", "x", "x")) {
+		return f.utilitiesConfig.Postgres13.Client,
+			f.utilitiesConfig.Postgres13.Dump,
+			f.utilitiesConfig.Postgres13.Restore,
+			nil
 	}
 
 	return "", "", "", fmt.Errorf("unsupported version of postgresql: %s.%s", semVer.Major, semVer.Minor)

--- a/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
@@ -37,10 +37,12 @@ var fakePgDump94 *binmock.Mock
 var fakePgDump96 *binmock.Mock
 var fakePgDump10 *binmock.Mock
 var fakePgDump11 *binmock.Mock
+var fakePgDump13 *binmock.Mock
 var fakePgRestore94 *binmock.Mock
 var fakePgRestore96 *binmock.Mock
 var fakePgRestore10 *binmock.Mock
 var fakePgRestore11 *binmock.Mock
+var fakePgRestore13 *binmock.Mock
 var fakePgClient *binmock.Mock
 var fakeMysqlClient55 *binmock.Mock
 var fakeMysqlDump55 *binmock.Mock
@@ -62,10 +64,12 @@ var _ = BeforeSuite(func() {
 	fakePgDump96 = binmock.NewBinMock(Fail)
 	fakePgDump10 = binmock.NewBinMock(Fail)
 	fakePgDump11 = binmock.NewBinMock(Fail)
+	fakePgDump13 = binmock.NewBinMock(Fail)
 	fakePgRestore94 = binmock.NewBinMock(Fail)
 	fakePgRestore96 = binmock.NewBinMock(Fail)
 	fakePgRestore10 = binmock.NewBinMock(Fail)
 	fakePgRestore11 = binmock.NewBinMock(Fail)
+	fakePgRestore13 = binmock.NewBinMock(Fail)
 	fakeMysqlDump55 = binmock.NewBinMock(Fail)
 	fakeMysqlClient55 = binmock.NewBinMock(Fail)
 	fakeMysqlDump56 = binmock.NewBinMock(Fail)
@@ -83,10 +87,12 @@ var _ = BeforeEach(func() {
 		"PG_DUMP_9_6_PATH":      "non-existent",
 		"PG_DUMP_10_PATH":       "non-existent",
 		"PG_DUMP_11_PATH":       "non-existent",
+		"PG_DUMP_13_PATH":       "non-existent",
 		"PG_RESTORE_9_4_PATH":   "non-existent",
 		"PG_RESTORE_9_6_PATH":   "non-existent",
 		"PG_RESTORE_10_PATH":    "non-existent",
 		"PG_RESTORE_11_PATH":    "non-existent",
+		"PG_RESTORE_13_PATH":    "non-existent",
 		"MARIADB_CLIENT_PATH":   "non-existent",
 		"MARIADB_DUMP_PATH":     "non-existent",
 		"MYSQL_CLIENT_5_5_PATH": "non-existent",

--- a/src/database-backup-restore/integration_tests/database_backup_restore_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_restore_test.go
@@ -133,6 +133,8 @@ var _ = Describe("Backup and Restore DB Utility", func() {
 	Context("missing environment variables", func() {
 		requiredEnvVars := []TableEntry{
 			Entry("pg_client path missing", "PG_CLIENT_PATH"),
+			Entry("pg_dump_13 path missing", "PG_DUMP_13_PATH"),
+			Entry("pg_restore_13 path missing", "PG_RESTORE_13_PATH"),
 			Entry("pg_dump_11 path missing", "PG_DUMP_11_PATH"),
 			Entry("pg_restore_11 path missing", "PG_RESTORE_11_PATH"),
 			Entry("pg_client path missing", "PG_CLIENT_PATH"),


### PR DESCRIPTION
We've added the postgres blob to the config, but you'll have to actually upload the binary to the blob store using `upload-blobs`, the postgres 13.2 tar.gz can be found here: https://www.postgresql.org/ftp/source/v13.2/

We've made a best attempt at updating the CI pipeline, but there may be mistakes in there since we can't really run it ourselves.

We did manually deploy bosh director v271.7.0 with postgres 13 and verified a backup-and-restore-sdk release with these changes was able both backup and restore it successfully.

The ci pipeline has a dependency on terraform templates stored in the private: https://github.com/pivotal-cf/cryogenics-meta. We have a commit for that, but don't have permission to make a branch or fork it. We'll drop you a patch file in slack for that, but again, it's just a best effort, there may be errors in it.