### PR TITLE
Update mysql compilation

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-boost/boost_1_76_0.tar.gz:
-  size: 130274594
-  object_id: 5cfdd20f-16ff-4dfd-467a-3d31864ac73c
-  sha: sha256:7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca
+boost/boost_1_59_0.tar.gz:
+  size: 83709983
+  object_id: 2bb21a57-51e9-471f-660a-edc788238fee
+  sha: 5123209db194d66d69a9cfa5af8ff473d5941d97
 libpcre2/pcre2-10.37.tar.gz:
   size: 2299767
   object_id: 8430a2b5-c852-413d-4286-3d1a44e8e61d

--- a/packages/database-backup-restorer-boost/packaging
+++ b/packages/database-backup-restorer-boost/packaging
@@ -17,4 +17,4 @@
 # abort script on any command that exits with a non zero value
 set -e
 
-tar -xzf boost/boost_1_76_0.tar.gz -C ${BOSH_INSTALL_TARGET}
+tar -xzf boost/boost_1_59_0.tar.gz -C ${BOSH_INSTALL_TARGET}

--- a/packages/database-backup-restorer-boost/spec
+++ b/packages/database-backup-restorer-boost/spec
@@ -20,4 +20,4 @@ name: database-backup-restorer-boost
 dependencies: []
 
 files:
-- boost/boost_1_76_0.tar.gz
+- boost/boost_1_59_0.tar.gz

--- a/packages/database-backup-restorer-mysql-5.6/packaging
+++ b/packages/database-backup-restorer-mysql-5.6/packaging
@@ -34,7 +34,7 @@ tar xzf mysql/mysql-${MYSQL_VERSION}.tar.gz
       -DWITH_SSL=system \
       -DWITH_WSREP=ON \
       -DWITH_INNODB_DISALLOW_WRITES=1 \
-      -DWITH_PCRE=bundled
+      -DWITH_PCRE=system
 
   set +e
   make -j 3 > build.out 2> build.err

--- a/packages/database-backup-restorer-mysql-5.6/spec
+++ b/packages/database-backup-restorer-mysql-5.6/spec
@@ -17,7 +17,8 @@
 ---
 name: database-backup-restorer-mysql-5.6
 
-dependencies: []
+dependencies:
+- libpcre2
 
 files:
 - mysql/mysql-5.6.51.tar.gz

--- a/packages/database-backup-restorer-mysql-5.7/packaging
+++ b/packages/database-backup-restorer-mysql-5.7/packaging
@@ -49,7 +49,7 @@ tar xzf mysql/mysql-${MYSQL_VERSION}.tar.gz
       -DWITH_SSL=system \
       -DWITH_WSREP=ON \
       -DWITH_INNODB_DISALLOW_WRITES=1 \
-      -DWITH_PCRE=bundled \
+      -DWITH_PCRE=system \
       -DWITH_BOOST=/var/vcap/packages/database-backup-restorer-boost/boost_1_59_0
 
   set +e

--- a/packages/database-backup-restorer-mysql-5.7/spec
+++ b/packages/database-backup-restorer-mysql-5.7/spec
@@ -17,7 +17,9 @@
 ---
 name: database-backup-restorer-mysql-5.7
 
-dependencies: [database-backup-restorer-boost]
+dependencies:
+- database-backup-restorer-boost
+- libpcre2
 
 files:
 - mysql/mysql-5.7.33.tar.gz


### PR DESCRIPTION
In this PR:

- Revert "Bump boost from 1.59.0 to 1.76.0 (#291)"
  - MySQL 5.7 requires boost pinned to 1.59.0
- Compile MySQL 5.6 and 5.7 with the libpcre2 bundled with the bosh release (see
  issue #265)
