### PR TITLE
ci: remove "pending" status update for pr resource

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -296,10 +296,10 @@ jobs:
           TRACKER_API_TOKEN: ((tracker.api_token))
           TRACKER_PROJECT_ID: ((tracker.project_id))
           ESTIMATE: 1
-    - put: backup-and-restore-sdk-release
-      params:
-        path: backup-and-restore-sdk-release
-        status: pending
+    # - put: backup-and-restore-sdk-release
+    #   params:
+    #     path: backup-and-restore-sdk-release
+    #     status: pending
     - task: sdk-template-unit-tests
       file: backup-and-restore-sdk-release/ci/tasks/sdk-template-unit-tests/task.yml
     - task: databases-unit-tests


### PR DESCRIPTION
We are having a few problems with the flow of PRs in our pipelines,
where some jobs are not triggered with new versions of the resources,
unless we "pin" the resource to a given version.

After a bit of investigation, we believe the `put` step in what's
causing the issue. Although we don't know why, we noticed the following:

When the pipeline has this format:

[PR --->] A ---- B ---- C
* PR triggers job A
* B uses the PR passed A
* C uses the PR passed C

All jobs trigger successfully

On the other hand, when we have something like:

[PR --->] A ---> B ---- C
* PR triggers job A
* A has a put step on the PR resource
* B uses the PR passed A
* C uses the PR passed C

The jobs A and B are triggered successfully. C is never triggered,
unless we pin the resource.

This PR is an attempt to validate on the above hypothesis.

Co-authored-by: Diego Lemos <dlemos@vmware.com>
