### PR TITLE
[package bumper] make blob bump strategy explicit

### DIFF
--- a/scripts/autobump-libpcre2.sh
+++ b/scripts/autobump-libpcre2.sh
@@ -20,3 +20,7 @@ function extract_version_callback() {
     local BLOB_ID="${1}"
     echo "${BLOB_ID}" | grep -Eo '[0-9]+\.[0-9]+'
 }
+
+function new_version_callback() {
+  echo "AUTO"
+}

--- a/scripts/autobump-mariadb.sh
+++ b/scripts/autobump-mariadb.sh
@@ -25,3 +25,7 @@ function download_url_callback() {
     local VERSION="${1}"
     echo "https://downloads.mariadb.org/interstitial/mariadb-${VERSION}/source/mariadb-${VERSION}.tar.gz"
 }
+
+function new_version_callback() {
+  echo "AUTO"
+}

--- a/scripts/autobump-mysql.sh
+++ b/scripts/autobump-mysql.sh
@@ -24,3 +24,7 @@ function download_url_callback() {
     local VERSION="${1}"
     echo "https://downloads.mysql.com/archives/get/p/23/file/mysql-${VERSION}.tar.gz"
 }
+
+function new_version_callback() {
+  echo "AUTO"
+}

--- a/scripts/autobump-postgresql.sh
+++ b/scripts/autobump-postgresql.sh
@@ -23,3 +23,7 @@ function download_url_callback() {
     local VERSION="${1}"
     echo "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.gz"
 }
+
+function new_version_callback() {
+  echo "AUTO"
+}


### PR DESCRIPTION
Now the package bump script we use requires the function `new_version_callback` to be defined.